### PR TITLE
Remove max k check in hnsw_search

### DIFF
--- a/R/hnsw.R
+++ b/R/hnsw.R
@@ -192,11 +192,6 @@ hnsw_search <- function(X, ann, k, ef = 10, verbose = FALSE) {
   }
   nr <- nrow(X)
 
-  max_k <- nr
-  if (k > max_k) {
-    stop("k cannot be larger than ", max_k)
-  }
-
   ef <- max(ef, k)
 
   idx <- matrix(nrow = nr, ncol = k)


### PR DESCRIPTION
The maximum k should check against the number of items in the index, but there does not seem to be a way to get that number. Currently, it prevents searching with one single data point.