### PR TITLE
Update README.md with more https URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/jlmelville/rcpphnsw?branch=master&svg=true)](https://ci.appveyor.com/project/jlmelville/rcpphnsw)
 [![R-CMD-check](https://github.com/jlmelville/rcpphnsw/workflows/R-CMD-check/badge.svg)](https://github.com/jlmelville/rcpphnsw/actions)
 [![Coverage Status](https://img.shields.io/codecov/c/github/jlmelville/rcpphnsw/master.svg)](https://codecov.io/github/jlmelville/rcpphnsw?branch=master)
-[![CRAN Status Badge](http://www.r-pkg.org/badges/version/RcppHNSW)](https://cran.r-project.org/package=RcppHNSW)
+[![CRAN Status Badge](https://www.r-pkg.org/badges/version/RcppHNSW)](https://cran.r-project.org/package=RcppHNSW)
 [![Dependencies](https://tinyverse.netlify.app/badge/RcppHNSW)](https://cran.r-project.org/package=RcppHNSW)
 [![CRAN Monthly Downloads](https://cranlogs.r-pkg.org/badges/RcppHNSW)](https://cran.r-project.org/package=RcppHNSW)
-![CRAN Downloads](http://cranlogs.r-pkg.org/badges/grand-total/RcppHNSW)
+![CRAN Downloads](https://cranlogs.r-pkg.org/badges/grand-total/RcppHNSW)
 [![Last Commit](https://img.shields.io/github/last-commit/jlmelville/rcpphnsw)](https://github.com/jlmelville/rcpphnsw)
 
 Rcpp bindings for [hnswlib](https://github.com/nmslib/hnswlib).


### PR DESCRIPTION
Was just coming via the [hnswlib](https://github.com/nmslib/hnswlib) and noticed that two of your badges looked sad -- I made similar fixes in a few of my repos too.  While the browser should know to follow from http to https it seemingly does not when looking at the repo.  FWIW looks better in my quickly-created fork:

![image](https://github.com/user-attachments/assets/66441725-f8d9-4afb-a782-eb9e1b77c7db)


Happy Holidays!